### PR TITLE
failing to recognized individuals

### DIFF
--- a/adascape/base.py
+++ b/adascape/base.py
@@ -399,14 +399,14 @@ class SpeciationModelBase:
 
         if disp_boundary is not None:
             hull = spatial.Delaunay(disp_boundary)
-            inhull = hull.find_simplex(np.column_stack([new_x, new_y])) <= 0
+            inhull = hull.find_simplex(np.column_stack([new_x, new_y])) < 0
 
             while any(inhull):
                 delta_bounds_x = self._grid_bounds['x'][:, None] - x[inhull]
                 delta_bounds_y = self._grid_bounds['y'][:, None] - y[inhull]
                 new_x[inhull] = self._truncnorm.rvs(*(delta_bounds_x / sigma), loc=x[inhull], scale=sigma)
                 new_y[inhull] = self._truncnorm.rvs(*(delta_bounds_y / sigma), loc=y[inhull], scale=sigma)
-                inhull = hull.find_simplex(np.column_stack([new_x, new_y])) <= 0
+                inhull = hull.find_simplex(np.column_stack([new_x, new_y])) < 0
         return new_x, new_y
 
     def _mutate_trait(self, trait, sigma):

--- a/adascape/tests/test_base.py
+++ b/adascape/tests/test_base.py
@@ -133,7 +133,7 @@ class TestIR12SpeciationModel:
         assert m._rng is rs
 
         m2 = IR12SpeciationModel(X, Y, init_trait_funcs, opt_trait_funcs, 10, random_seed=0)
-        np.testing.assert_equal(m2._rng.__getstate__()['state'], rs.__getstate__()['state'])
+        np.testing.assert_equal(m2._rng.random(10), rs.random(10))
 
     def test_params(self, params_IR12, model_IR12):
         assert model_IR12.params == params_IR12

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
     - toytree
     - toyplot
     - pytest
+    - zarr<3
     - pip
     - pip:
         - 'git+https://github.com/EstebanAce/orographic-precipitation.git'


### PR DESCRIPTION
Jean found a bug in which some of the individuals were not detected when one set up a polygon (island-like environment) on the bounded dispersal option. We fixed the bug by modifying the condition.